### PR TITLE
test: add integration test target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,13 @@ BIN := falcon
 build: ## Build the CLI binary to ./falcon
 	$(GO) build -o $(BIN) $(PKG)
 
-test: ## Run tests with race detector and coverage
+# Unit tests only (test files without //go:build integration header)
+test: ## Run unit tests
 	$(GO) test -race -cover ./...
+
+# Unit and integration tests (also files with //go:build integration header)
+test-with-integration: ## Run unit + integration tests
+	$(GO) test -race -cover -tags=integration ./...
 
 vet: ## Static analysis
 	$(GO) vet ./...
@@ -21,11 +26,16 @@ format: ## Format code (goimports if available, then gofmt)
 lint: ## Run golangci-lint
 	golangci-lint run
 
-check: ## Run vet, lint, and tests (no writes)
+check: ## Run format, vet, lint, and test
+	@$(MAKE) format
 	@$(MAKE) vet
 	@$(MAKE) lint
 	@$(MAKE) test
 
+clean: ## Remove the built binary
+	rm -f $(BIN)
+
+# Not included: test-with-integration, clean
 all: ## Format, vet, lint, test, then build
 	@$(MAKE) format
 	@$(MAKE) vet

--- a/algorand/send_test.go
+++ b/algorand/send_test.go
@@ -1,0 +1,24 @@
+//go:build integration
+
+package algorand
+
+import (
+	"bytes"
+	_ "embed"
+	"testing"
+)
+
+//go:embed teal/dummyLsig.teal
+var dummyLsigTeal string
+
+func TestDummyTealCompilation(t *testing.T) {
+	compiled, err := CompileLogicSig(dummyLsigTeal)
+	if err != nil {
+		t.Fatalf("failed to compile dummy teal: %v", err)
+	}
+	tealBytes := compiled.Lsig.Logic
+
+	if !bytes.Equal(tealBytes, dummyLsigCompiled) {
+		t.Fatalf("compiled bytes do not match expected bytes")
+	}
+}


### PR DESCRIPTION
  - Add test-with-integration target to Makefile to run integration tests in addition to unit tests
  - Add clean target to remove built binary
  - Update check target to include format step
  
  With this PR we can mark tests that need an algorand node as "integration tests" and run them in addition to unit tests with `make test-with-integration`
  
  `make test` will exclude those tests