### PR TITLE
api: falcon sign/verify raw bytes directly

### DIFF
--- a/algorand/send.go
+++ b/algorand/send.go
@@ -70,7 +70,7 @@ func Send(keyPair falcongo.KeyPair, to string, amount uint64, opt SendOptions,
 	}
 
 	txnToSign := sendGroup[0]
-	signature, err := keyPair.SignBytes(crypto.TransactionID(txnToSign))
+	signature, err := keyPair.Sign(crypto.TransactionID(txnToSign))
 	if err != nil {
 		return "", err
 	}

--- a/falcongo/falcon.go
+++ b/falcongo/falcon.go
@@ -2,7 +2,6 @@ package falcongo
 
 import (
 	"crypto/rand"
-	"crypto/sha512"
 	"fmt"
 
 	"github.com/algorand/falcon"
@@ -15,11 +14,6 @@ type PrivateKey = falcon.PrivateKey
 type KeyPair struct {
 	PublicKey  PublicKey
 	PrivateKey PrivateKey
-}
-
-// Hash computes the SHA-512/256 hash of the input bytes.
-func Hash(data []byte) [32]byte {
-	return sha512.Sum512_256(data)
 }
 
 // GenerateKeyPair generates a new Falcon keypair from a given seed.
@@ -37,26 +31,14 @@ func GenerateKeyPair(seed []byte) (KeyPair, error) {
 	return KeyPair{PublicKey: pk, PrivateKey: sk}, err
 }
 
-// Sign hashes the message with SHA-512/256 and signs the digest.
-func (d *KeyPair) Sign(message []byte) (falcon.CompressedSignature, error) {
-	hs := Hash(message)
-	return d.SignBytes(hs[:])
-}
-
-// SignBytes signs the provided bytes directly.
-func (d *KeyPair) SignBytes(data []byte) (falcon.CompressedSignature, error) {
+// Sign signs the provided bytes using the private key and returns a compressed signature.
+func (d *KeyPair) Sign(data []byte) (falcon.CompressedSignature, error) {
 	signedData, err := (*falcon.PrivateKey)(&d.PrivateKey).SignCompressed(data)
 	return falcon.CompressedSignature(signedData), err
 }
 
-// Verify verifies a signature over message using the provided public key.
-func Verify(message []byte, sig falcon.CompressedSignature, pk falcon.PublicKey) error {
-	hs := Hash(message)
-	return VerifyBytes(hs[:], sig, pk)
-}
-
-// VerifyBytes verifies a signature over raw bytes using the provided public key.
-func VerifyBytes(data []byte, sig falcon.CompressedSignature, pk falcon.PublicKey) error {
+// Verify verifies the signature of the provided data using the public key.
+func Verify(data []byte, sig falcon.CompressedSignature, pk falcon.PublicKey) error {
 	return pk.Verify(sig, data)
 }
 

--- a/falcongo/falcon_test.go
+++ b/falcongo/falcon_test.go
@@ -132,29 +132,6 @@ func TestSign_ValidMessage(t *testing.T) {
 	}
 }
 
-func TestSignBytes_DirectBytesSigning(t *testing.T) {
-	seed := make([]byte, 48)
-	if _, err := rand.Read(seed); err != nil {
-		t.Fatalf("rand.Read: %v", err)
-	}
-
-	keypair, err := GenerateKeyPair(seed)
-	if err != nil {
-		t.Fatalf("Failed to generate keypair: %v", err)
-	}
-
-	testData := []byte("test data for direct signing")
-
-	signature, err := keypair.SignBytes(testData)
-	if err != nil {
-		t.Fatalf("Failed to sign bytes: %v", err)
-	}
-
-	if len(signature) == 0 {
-		t.Error("Signature should not be empty")
-	}
-}
-
 func TestVerify_ValidSignature(t *testing.T) {
 	seed := make([]byte, 48)
 	if _, err := rand.Read(seed); err != nil {
@@ -238,36 +215,6 @@ func TestVerify_WrongPublicKey(t *testing.T) {
 	}
 }
 
-func TestVerifyBytes_DirectBytesVerification(t *testing.T) {
-	seed := make([]byte, 48)
-	if _, err := rand.Read(seed); err != nil {
-		t.Fatalf("rand.Read: %v", err)
-	}
-
-	keypair, err := GenerateKeyPair(seed)
-	if err != nil {
-		t.Fatalf("Failed to generate keypair: %v", err)
-	}
-
-	testData := []byte("test data for direct verification")
-
-	signature, err := keypair.SignBytes(testData)
-	if err != nil {
-		t.Fatalf("Failed to sign bytes: %v", err)
-	}
-
-	err = VerifyBytes(testData, signature, keypair.PublicKey)
-	if err != nil {
-		t.Errorf("Valid signature should verify bytes successfully: %v", err)
-	}
-
-	tamperedData := []byte("tampered data for direct verification")
-	err = VerifyBytes(tamperedData, signature, keypair.PublicKey)
-	if err == nil {
-		t.Error("Tampered data should not verify")
-	}
-}
-
 func TestSignAndVerify_RoundTrip(t *testing.T) {
 	seed := make([]byte, 48)
 	if _, err := rand.Read(seed); err != nil {
@@ -326,28 +273,6 @@ func TestGetFixedLengthSignature(t *testing.T) {
 
 	if len(fixedLengthSig) == 0 {
 		t.Error("Fixed-length signature should not be empty")
-	}
-}
-
-func TestHash_Consistency(t *testing.T) {
-	testData := []byte("test data for hashing")
-
-	hash1 := Hash(testData)
-	hash2 := Hash(testData)
-
-	if !bytes.Equal(hash1[:], hash2[:]) {
-		t.Error("Hash function should be deterministic")
-	}
-
-	if len(hash1) != 32 {
-		t.Errorf("Hash should be 32 bytes, got %d", len(hash1))
-	}
-
-	differentData := []byte("different test data for hashing")
-	hash3 := Hash(differentData)
-
-	if bytes.Equal(hash1[:], hash3[:]) {
-		t.Error("Different data should produce different hashes")
 	}
 }
 


### PR DESCRIPTION
  - Remove SHA-512/256 pre-hashing from signing and verification with `falcon sign` and `falcon verify`
  
  This aligns behavior with the falcon_verify opcode