### PR TITLE
go.mod: set go 1.25 in directive (drop patch)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/algorandfoundation/falcon-signatures
 
-go 1.25.0
+go 1.25
 
 require github.com/algorand/falcon v0.1.0
 


### PR DESCRIPTION
- Go directive is expected to be minor-only