### PR TITLE
detect version from build metadata for go install

### DIFF
--- a/cli/version.go
+++ b/cli/version.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 )
 
 // version holds the build version string injected at link-time.
@@ -15,13 +16,25 @@ func runVersion(args []string) int {
 		return 2
 	}
 
-	fmt.Fprintln(os.Stdout, version)
+	builtVersion := version
+	if builtVersion == "" {
+		builtVersion = "dev"
+	}
+	if builtVersion == "dev" {
+		if buildInfo, ok := debug.ReadBuildInfo(); ok {
+			if v := buildInfo.Main.Version; v != "" && v != "(devel)" {
+				builtVersion = v
+			}
+		}
+	}
+
+	fmt.Fprintln(os.Stdout, builtVersion)
 	return 0
 }
 
 const helpVersion = `# falcon version
 
-Show the CLI build version. Local builds print "dev"; released binaries include their release version.
+Show the CLI build version. Local builds print "dev"; binaries installed via go install or release builds include their tagged version.
 
 Usage:
   falcon version

--- a/docs/version.md
+++ b/docs/version.md
@@ -7,3 +7,5 @@ Show the `falcon` CLI build version.
 ```bash
 falcon version
 ```
+
+Local builds print `dev`. Binaries installed with `go install github.com/algorandfoundation/falcon-signatures/cmd/falcon@<version>` or downloaded from releases report the tagged version.


### PR DESCRIPTION
This makes `falcon version` work when installing it with `go install ...`