### PR TITLE
docs: add Docker usage instructions and examples to README and help documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.25 AS builder
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN make build
+
+FROM debian:bookworm-slim
+
+WORKDIR /work
+
+COPY --from=builder /src/build/falcon /usr/local/bin/falcon
+
+ENTRYPOINT ["falcon"]
+CMD ["help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN make build
 
 FROM debian:bookworm-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+ 	&& rm -rf /var/lib/apt/lists/*
 WORKDIR /work
 
 COPY --from=builder /src/build/falcon /usr/local/bin/falcon

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
+RUN mkdir -p build
 RUN make build
 
 FROM debian:bookworm-slim

--- a/README.md
+++ b/README.md
@@ -61,6 +61,26 @@ Run `make help` to see all available commands.
 
 ---
 
+#### Build and run with Docker
+
+If you prefer not to install Go locally, you can build and run `falcon` with Docker:
+
+```bash
+docker build -t falcon .
+docker run --rm falcon help
+```
+
+To use local files such as keypairs, signatures, or message files, mount the current directory into the container:
+
+```bash
+docker run --rm -v "$PWD:/work" -w /work falcon create --out mykeys.json
+docker run --rm -v "$PWD:/work" -w /work falcon sign --key mykeys.json --msg "hello world"
+```
+
+See [`docs/docker.md`](docs/docker.md) for more Docker examples.
+
+---
+
 ## Usage
 
 Available commands:
@@ -74,6 +94,7 @@ Available commands:
 | [`falcon version`](docs/version.md) | Show the CLI build version |
 | [`falcon help`](docs/help.md) | Show help |
 | [`falcon algorand`](docs/algorand.md) | Algorand-specific commands |
+| [`Docker usage`](docs/docker.md) | Build and run `falcon` with Docker |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ docker run --rm -v "$PWD:/work" -w /work falcon create --out mykeys.json
 docker run --rm -v "$PWD:/work" -w /work falcon sign --key mykeys.json --msg "hello world"
 ```
 
+On Linux/macOS, consider adding `--user "$(id -u):$(id -g)"` to `docker run` so files written to mounted volumes aren't owned by root.
+
 See [`docs/docker.md`](docs/docker.md) for more Docker examples.
 
 ---

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,46 @@
+# Docker usage
+
+Build and run the `falcon` CLI with Docker.
+
+## Build the image
+
+From the repository root:
+
+```bash
+docker build -t falcon .
+```
+
+This builds the CLI inside a Go 1.25 container and produces a runtime image with the `falcon` binary as its entrypoint.
+
+## Run commands
+
+Show help:
+
+```bash
+docker run --rm falcon help
+```
+
+Show the version:
+
+```bash
+docker run --rm falcon version
+```
+
+## Work with local files
+
+Most commands read or write files. Mount a host directory into `/work` and run the container from there:
+
+```bash
+docker run --rm -v "$PWD:/work" -w /work falcon create --out mykeys.json
+docker run --rm -v "$PWD:/work" -w /work falcon sign --key mykeys.json --msg "hello world" --out hello.sig
+docker run --rm -v "$PWD:/work" -w /work falcon verify --key mykeys.json --msg "hello world" --sig hello.sig
+```
+
+## Notes
+
+- The container entrypoint is `falcon`, so anything after the image name is passed directly to the CLI.
+- On Windows PowerShell, use `${PWD}:/work` instead of `$PWD:/work` if needed:
+
+```powershell
+docker run --rm -v "${PWD}:/work" -w /work falcon help
+```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -39,6 +39,7 @@ docker run --rm -v "$PWD:/work" -w /work falcon verify --key mykeys.json --msg "
 ## Notes
 
 - The container entrypoint is `falcon`, so anything after the image name is passed directly to the CLI.
+- On Linux/macOS, consider `--user "$(id -u):$(id -g)"` so created files in mounted volumes aren't owned by root.
 - On Windows PowerShell, use `${PWD}:/work` instead of `$PWD:/work` if needed:
 
 ```powershell

--- a/docs/help.md
+++ b/docs/help.md
@@ -19,3 +19,11 @@ Show help for a specific command:
 ```bash
 falcon help create
 ```
+
+Run help through Docker:
+
+```bash
+docker run --rm falcon help
+```
+
+Build and file-mount examples are in [docs/docker.md](docker.md).


### PR DESCRIPTION
allow docker support, so that people do not have to install go to use the falcon